### PR TITLE
Add timeline / seeking

### DIFF
--- a/vlc-win10smtc/module.cpp
+++ b/vlc-win10smtc/module.cpp
@@ -20,9 +20,23 @@
 #pragma comment(lib, "Shlwapi.lib")
 #define DEFAULT_THUMBNAIL_URI L"https://upload.wikimedia.org/wikipedia/commons/3/38/VLC_icon.png"
 
-// uh
-using namespace winrt::Windows::Media;
+void DebugOut(wchar_t* fmt, ...)
+{
+    va_list argp;
+    va_start(argp, fmt);
+    wchar_t dbg_out[4096];
+    vswprintf_s(dbg_out, fmt, argp);
+    va_end(argp);
+    OutputDebugString(dbg_out);
+}
 
+// uh
+using namespace winrt::Windows::Foundation;
+using namespace winrt::Windows::Media;
+using namespace std::chrono;
+using namespace std;
+
+using pts = duration<long long, ratio<1, 1000000>>;
 
 struct intf_sys_t
 {
@@ -36,8 +50,15 @@ struct intf_sys_t
         playlist{ pl_Get(intf) },
         input{ nullptr },
         advertise{ false },
-        metadata_advertised{ false }
+        metadata_advertised{ false },
+        position{ -1 },
+        length{ -1 }
     {
+        timeLine.StartTime(TimeSpan::zero());
+        timeLine.MinSeekTime(TimeSpan::zero());
+        timeLine.Position(TimeSpan::zero());
+        timeLine.MaxSeekTime(TimeSpan::zero());
+        timeLine.EndTime(TimeSpan::zero());
     }
 
     void InitializeMediaPlayer()
@@ -49,6 +70,7 @@ struct intf_sys_t
 
         SMTC().ButtonPressed(
             [this](SystemMediaTransportControls sender, SystemMediaTransportControlsButtonPressedEventArgs args) {
+                int64_t jmpsz = 0;
                 playlist_Lock(playlist);
 
                 switch (args.Button()) {
@@ -71,6 +93,18 @@ struct intf_sys_t
                 case SystemMediaTransportControlsButton::Previous:
                     playlist_Prev(playlist);
                     break;
+
+                case SystemMediaTransportControlsButton::FastForward:
+                    DebugOut(L"SMTC ff via Button\n");
+                    jmpsz = var_InheritInteger(intf, "extrashort-jump-size");
+                    var_SetInteger(input, "time-offset", jmpsz);
+                    break;
+
+                case SystemMediaTransportControlsButton::Rewind:
+                    DebugOut(L"SMTC rew via Button\n");
+                    jmpsz = var_InheritInteger(intf, "extrashort-jump-size");
+                    var_SetInteger(input, "time-offset", -jmpsz);
+                    break;
                 }
 
                 playlist_Unlock(playlist);
@@ -83,12 +117,30 @@ struct intf_sys_t
         SMTC().IsPreviousEnabled(true);
         SMTC().IsNextEnabled(true);
 
+        SMTC().PlaybackPositionChangeRequested([this](SystemMediaTransportControls sender, PlaybackPositionChangeRequestedEventArgs args) {
+            int64_t pos = args.RequestedPlaybackPosition().count()/10;
+            if (pos == 10000000) {
+                // that's how we get one click forward...?
+                DebugOut(L"SMTC ff via PositionChange\n");
+                var_SetInteger(input, "time-offset", pos);
+            } else if (pos == -10000000) {
+                // or backward, respectively...
+                DebugOut(L"SMTC rew via PositionChange\n");
+                var_SetInteger(input, "time-offset", pos);
+            } else {
+                // seek to absolute position from timeline
+                DebugOut(L"SMTC seeking to %lld\n", pos);
+                var_SetInteger(input, "time", pos);
+            }
+            }
+        );
+
         SMTC().PlaybackStatus(MediaPlaybackStatus::Closed);
         SMTC().IsEnabled(true);
 
         winrt::Windows::Foundation::Uri uri{ DEFAULT_THUMBNAIL_URI };
         defaultArt = winrt::Windows::Storage::Streams::RandomAccessStreamReference::CreateFromUri(uri);
-        
+
         Disp().Thumbnail(defaultArt);
         Disp().Type(MediaPlaybackType::Music);
         Disp().Update();
@@ -103,6 +155,10 @@ struct intf_sys_t
     void AdvertiseState()
     {
         static_assert((int)MediaPlaybackStatus::Closed == 0, "Treat default case explicitely");
+
+        DebugOut(L"SMTC setting seekable: %s\n", seekable ? L"true" : L"false");
+        SMTC().IsFastForwardEnabled(seekable);
+        SMTC().IsRewindEnabled(seekable);
 
         static std::unordered_map<input_state_e, MediaPlaybackStatus> map = {
             {OPENING_S, MediaPlaybackStatus::Changing},
@@ -138,7 +194,7 @@ struct intf_sys_t
             }
 
             return ret;
-        };
+            };
 
         title = to_hstring(input_item_GetTitleFbName(item), L"Unknown Title");
         artist = to_hstring(input_item_GetArtist(item), L"Unknown Artist");
@@ -184,6 +240,22 @@ struct intf_sys_t
         Disp().Update();
     }
 
+    void AdvertiseLength() {
+        TimeSpan len = pts{ length };
+        timeLine.MaxSeekTime(len);
+        timeLine.EndTime(len);
+        SMTC().UpdateTimelineProperties(timeLine);
+
+        DebugOut(L"SMTC TimeLine len: %lld/%lld\n", timeLine.Position(), len);
+    }
+    void AdvertisePosition() {
+        TimeSpan pos = pts{ position };
+        timeLine.Position(pos);
+        SMTC().UpdateTimelineProperties(timeLine);
+
+        DebugOut(L"SMTC TimeLine pos: %lld/%lld\n", pos, timeLine.EndTime());
+    }
+
     SystemMediaTransportControls SMTC() {
         return mediaPlayer.SystemMediaTransportControls();
     }
@@ -194,11 +266,15 @@ struct intf_sys_t
 
     Playback::MediaPlayer mediaPlayer;
     winrt::Windows::Storage::Streams::RandomAccessStreamReference defaultArt;
+    SystemMediaTransportControlsTimelineProperties timeLine;
 
     intf_thread_t* intf;
     playlist_t* playlist;
     input_thread_t* input;
     input_state_e input_state;
+    bool seekable;
+    int64_t position;
+    int64_t length;
     vlc_thread_t thread;
     vlc_mutex_t lock;
     vlc_cond_t wait;
@@ -218,20 +294,26 @@ int InputEvent(vlc_object_t* object, char const* cmd,
     intf_sys_t* sys = intf->p_sys;
     input_thread_t* input = (input_thread_t*)object;
 
-    if (newval.i_int == INPUT_EVENT_STATE) {
-        input_state_e state = (input_state_e)var_GetInteger(input, "state");
-
-        // send update to winrt thread
-        vlc_mutex_lock(&sys->lock);
-        sys->advertise = true;
-        sys->input_state = state;
-        vlc_cond_signal(&sys->wait);
-        vlc_mutex_unlock(&sys->lock);
-    }
-    else if (newval.i_int == INPUT_EVENT_DEAD) {
+    // send appropriate update to winrt thread
+    if (newval.i_int == INPUT_EVENT_DEAD) {
         assert(sys->input);
         vlc_object_release(sys->input);
         sys->input = nullptr;
+    } else {
+        vlc_mutex_lock(&sys->lock);
+
+        if (newval.i_int == INPUT_EVENT_STATE) {
+            sys->advertise = true;
+            sys->input_state = (input_state_e)var_GetInteger(input, "state");
+            sys->seekable = var_GetBool(input, "can-seek");
+        } else if (newval.i_int == INPUT_EVENT_LENGTH) {
+            sys->length = var_GetInteger(input, "length");
+        } else if (newval.i_int == INPUT_EVENT_POSITION) {
+            sys->position = var_GetInteger(input, "time");
+        }
+
+        vlc_cond_signal(&sys->wait);
+        vlc_mutex_unlock(&sys->lock);
     }
 
     return VLC_SUCCESS;
@@ -251,6 +333,7 @@ int PlaylistEvent(vlc_object_t* object, char const* cmd,
 
     sys->metadata_advertised = false; // new song, mark it as unadvertised
     sys->input = (input_thread_t*)vlc_object_hold(input);
+    // delete previous...? ~jmbreuer
     var_AddCallback(input, "intf-event", InputEvent, intf);
 
     return VLC_SUCCESS;
@@ -286,6 +369,16 @@ void* Thread(void* handle)
         }
         sys->advertise = false;
 
+        if (sys->length != -1) {
+            sys->AdvertiseLength();
+            sys->length = -1;
+        }
+
+        if (sys->input_state >= PLAYING_S && sys->position != -1) {
+            sys->AdvertisePosition();
+            sys->position = -1;
+        }
+
         vlc_restorecancel(canc);
 
         vlc_cleanup_pop();
@@ -299,6 +392,8 @@ void* Thread(void* handle)
 
 int Open(vlc_object_t* object)
 {
+    DebugOut(L"VLC SMTC module initializing...\n");
+
     intf_thread_t* intf = (intf_thread_t*)object;
     intf_sys_t* sys = new intf_sys_t(intf);
 


### PR DESCRIPTION
Hi,

first of all thanks for that great little project!

I love using this together with [KDE Connect](https://kdeconnect.kde.org) to use my phone as a quick & dirty remote for VLC (on Windows, under Linux this already immediately works thanks to [MPRIS](https://specifications.freedesktop.org/mpris-spec/latest/index.html)).

Having timeline seeking / that 'skip back 10 seconds' button turned out to be desirous enough for me to sit down a couple of hours and code up these additions. 😉

This is not so much intended as a ready-to-go pull request, but rather to let everyone know that my fork exists, and what additional features it might offer. I'm looking into volume control next, that's a bit cumbersome with KDE Connect and VLC under Windows, but again works smoothly under Linux out-of-the-box.